### PR TITLE
chore: change http depdency restriction from <1.0.0 to <2.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   visibility_detector: ">=0.2.0 <1.0.0"
   flutter_hooks: ">=0.16.0 <1.0.0"
-  http: ">=0.13.1 <1.0.0"
+  http: ">=0.13.1 <2.0.0"
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
I think this limit was only in place to protect from breaking changes on `http` `1.0.0` release?

Now `http` `1.0.0` is released and there aren't any breaking changes, so I think there's no further reason to hold back the users.

From the `http` [release notes](https://pub.dev/packages/http/changelog):
```
1.0.0

    Requires Dart 3.0 or later.
    Add base, final, and interface modifiers to some classes.
```