### PR TITLE
style: fix typo in error handler parameters

### DIFF
--- a/lib/src/mjpeg.dart
+++ b/lib/src/mjpeg.dart
@@ -45,7 +45,7 @@ class Mjpeg extends HookWidget {
   final Duration timeout;
   final WidgetBuilder? loading;
   final Client? httpClient;
-  final Widget Function(BuildContext contet, dynamic error, dynamic stack)?
+  final Widget Function(BuildContext context, dynamic error, dynamic stack)?
       error;
   final Map<String, String> headers;
   final MjpegPreprocessor? preprocessor;


### PR DESCRIPTION
This PR fixes a very small typo (`contet` → `context`) in the parameters of the `Mjpeg` widget's `error` handler.