### PR TITLE
Add support for frameTimeout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Parameter | Description
 --- | ---
 `isLive` | Whether or not the stream should be loaded continuously
 `timeout` | HTTP Timeout when fetching the MJPEG stream
+`frameTimeout` | If no frame is received for this duration, the stream will be reloaded. This should only be used together with `isLive` as there's no point in waiting for new frames in a stream that's not live.
 `width` | Force width
 `height` | Force height
 `error` | Error builder used when an error occurred


### PR DESCRIPTION
Implements the request from https://github.com/mylisabox/flutter_mjpeg/issues/36.

This adds a `frameTimeout` option that can be passed a Duration. The option is expected to be used with streams where `isLive=true`, so that there is a timeout between receiving frames. If no new frame is received for the given timeout duration, the stream is automatically reloaded.

We have been using this in our desktop app to get streams to reload after the machine entered sleep mode and it has worked very well for the past (almost) two months.